### PR TITLE
Adds valis auth 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
         cache: pip
         cache-dependency-path: |
           **/setup.cfg

--- a/python/sdss_brain/auth/user.py
+++ b/python/sdss_brain/auth/user.py
@@ -57,6 +57,7 @@ class User(object):
         self._valid_netrc = False
         self._valid_htpass = False
         self._valid_sdss_cred = False
+        self._validated_netrc_host = None
 
         self._setup_auths()
 
@@ -75,6 +76,12 @@ class User(object):
         except BrainError:
             self.netrc = None
         else:
+            net_hosts = ['data.sdss.org', 'api.sdss.org', 'data.sdss5.org', 'wiki.sdss.org']
+            self._valid_netrc = any(self.user in
+                                    self.netrc.read_netrc(vhost:= h)
+                                    for h in net_hosts)
+            self._validated_netrc_host = vhost if self._valid_netrc else None
+
             self._valid_netrc = (self.user in self.netrc.read_netrc('data.sdss.org') or
                                  self.user in self.netrc.read_netrc('api.sdss.org') or
                                  self.user in self.netrc.read_netrc('data.sdss5.org') or
@@ -145,6 +152,8 @@ class User(object):
                     user, passwd = self.netrc.read_netrc(host)
                 except ValueError:
                     pass
+                else:
+                    self._validated_netrc_host = host
 
             if user != self.user:
                 raise ValueError(f'netrc user {user} mismatched with input user {self.user}!')

--- a/python/sdss_brain/etc/api_profiles.yml
+++ b/python/sdss_brain/etc/api_profiles.yml
@@ -116,3 +116,6 @@ apis:
     base: valis
     domains:
       - api
+    auth:
+      type: token
+      route: auth/login

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,15 +18,15 @@ classifiers =
 	Natural Language :: English
 	Operating System :: OS Independent
 	Programming Language :: Python
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Topic :: Documentation :: Sphinx
 	Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.8
 packages = find:
 package_dir =
 	= python


### PR DESCRIPTION
This PR closes #17.  It updates the collab auth to the production url and updates the valis API profile to include its login info.  When constructing the token url, it now looks for the user's validated netrc host and uses that for password lookup.  If none is found, defaults to api.sdss.org.    It also sets the min python version to python 3.8, so we can start using walrus operators.