### PR TITLE
Adds methods for refreshing tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,18 +39,14 @@ jobs:
       with:
         machine: data.sdss.org
         username: sdss
-        password: test
+        password: stest
 
     - name: Setup SDSS API netrc
       uses: extractions/netrc@v1
       with:
         machine: api.sdss.org
         username: sdss
-        password: test
-
-    # Enable tmate debugging of manually-triggered workflows if the input option was provided
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+        password: stest
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,14 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Setup SDSS netrc
+    - name: Setup SDSS data netrc
+      uses: extractions/netrc@v1
+      with:
+        machine: data.sdss.org
+        username: sdss
+        password: test
+
+    - name: Setup SDSS API netrc
       uses: extractions/netrc@v1
       with:
         machine: api.sdss.org

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,13 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Setup SDSS netrc
+      uses: extractions/netrc@v1
+      with:
+        machine: api.sdss.org
+        username: sdss
+        password: test
+
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,7 @@
 
 name: Build and Test
 
-
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
+on: [push, pull_request]
 
 jobs:
   build:
@@ -26,7 +16,6 @@ jobs:
     # Enable tmate debugging of manually-triggered workflows if the input option was provided
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # Enable tmate debugging of manually-triggered workflows if the input option was provided
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -51,6 +47,10 @@ jobs:
         machine: api.sdss.org
         username: sdss
         password: test
+
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,17 @@
 
 name: Build and Test
 
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
   build:
@@ -12,6 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/docs/sphinx/apilist.rst
+++ b/docs/sphinx/apilist.rst
@@ -21,6 +21,7 @@ internal   internal.sdss.org   False     domain for accessing internal SDSS info
 magrathea  magrathea.sdss.org  False     mirror domain for SDSS services, e.g. SDSS MaNGA's Marvin
 dr15       dr15.sdss.org       True      public domain for DR15 data access
 dr16       dr16.sdss.org       True      public domain for DR16 data access
+dr17       dr17.sdss.org       True      public domain for DR17 data access
 local      localhost           False     domain when running services locally
 =========  ==================  ========  =========================================================
 
@@ -30,10 +31,10 @@ APIs
 ----
 Available APIs serving various SDSS content and/or data
 
-======  =============  ================================================  ============================  =========  ======  ===============================================================
-key     base           description                                       domains                       mirrors    auth    docs
-======  =============  ================================================  ============================  =========  ======  ===============================================================
-marvin  marvin         API for accessing MaNGA data via Marvin           sas, lore, dr15, dr16, local  magrathea  token   https://sdss-marvin.readthedocs.io/en/stable/reference/web.html
-icdb    collaboration  API for accessing SDSS collaboration information  internal, local                          netrc
-valis   valis          API for SDSS data access                          api, local                               netrc
-======  =============  ================================================  ============================  =========  ======  ===============================================================
+======  =============  ================================================  ============================  =========  ======  =============== ===============================================================
+key     base           description                                       domains                       mirrors    auth    users           docs
+======  =============  ================================================  ============================  =========  ======  =============== ===============================================================
+marvin  marvin         API for accessing MaNGA data via Marvin           sas, lore, dr15, dr16, local  magrathea  token   sdss, collab    https://sdss-marvin.readthedocs.io/en/stable/reference/web.html
+icdb    collaboration  API for accessing SDSS collaboration information  internal, local                          netrc   collab
+valis   valis          API for SDSS data access                          api, local                               token   collab          https://api.sdss.org/valis/docs
+======  =============  ================================================  ============================  =========  ======  =============== ===============================================================

--- a/docs/sphinx/auth.rst
+++ b/docs/sphinx/auth.rst
@@ -26,9 +26,16 @@ edit a file in your home directory ocalled ``.netrc`` and copy these lines insid
        login <username>
        password <password>
 
+    machine data.sdss5.org
+       login <username>
+       password <password>
+
 Replace ``<username>`` and ``<password>`` with your login credentials. The default SDSS username and
 password is also acceptable for anonymous access.  **Finally, run** ``chmod 600 ~/.netrc`` **to make
 the file only accessible to your user.**
+
+The machine host ``data.sdss5.org`` is for accessing proprietary SDSS-V data, where ``data.sdss.org`` is
+for accessing any legacy proprietary SDSS data.
 
 .. _token:
 
@@ -57,7 +64,7 @@ To check if a valid token is already set, access the ``token`` attribute or use 
 
 ``check_for_token`` looks for a valid API token in your list of environment variables or as a parameter set on your custom
 ``sdss_brain.yml`` configuration file.  To retrieve a valid token, use the `~sdss_brain.api.manager.ApiProfile.get_token`
-method.  Tokens are mapped to specific users, either the "sdss" user or your SDSS username.  The ``get_token`` method
+method.  Tokens are mapped to specific users, either the "sdss/sdss5" users or your SDSS username.  The ``get_token`` method
 looks for user credentials in your ``.netrc`` file, so make sure you pass the username that is listed under the
 ``api.sdss.org`` machine in your ``.netrc``.
 ::
@@ -82,6 +89,38 @@ authentication.  The ``SDSSClient`` will check for a valid token for its current
 its currently set `~sdss_brain.api.manager.ApiProfile`.  If you haven't already set a token, you can do so with the
 client's `~sdss_brain.api.client.SDSSClient.get_token` method.
 
+.. _refresh:
+
+Token Refreshing
+----------------
+
+With OAuth tokens, authorization access tokens will expire after a certain amount of time.  You can refresh your access with a
+``refresh_token``, issued by certain APIs with calls to `~sdss_brain.api.manager.ApiProfile.get_token`, e.g. Valis.  Refresh tokens
+should be stored in an **[NAME]_API_REFRESH_TOKEN** environment variable or as a **[name]_api_refresh_token** parameter in
+your ``sdss_brain.yml`` custom configuration file.  **[NAME]** references the name of the specific API.  For example,
+with the "valis" API, you would set either a **VALIS_API_REFRESH_TOKEN** environment variable
+or **valis_api_refresh_token** configuration parameter.
+
+To check if a valid refresh token is already set, access the ``refresh_token`` attribute or use the
+`~sdss_brain.api.manager.ApiProfile.check_for_refresh_token` method.
+::
+
+    >>> # check for a valid refresh token
+    >>> prof.check_for_refresh_token()
+    None
+
+If a valid refresh token exists, you can refresh your access token using the `~sdss_brain.api.manager.ApiProfile.refresh_auth_token` method.
+::
+
+    >>> # refresh an access token
+    >>> prof.refresh_auth_token()
+
+This will issue a new access ``token`` which you should replace in your **[NAME]_API_TOKEN** environment variable or your
+``sdss_brain.yml`` custom configuration file.
+
+.. note::
+    Not all APIs will issue refresh tokens.  In these cases, ``refresh_token`` will remain None.  Currently only the
+    Valis API issues refresh tokens for its authorization.
 
 .. _users:
 
@@ -92,10 +131,11 @@ Remote data access requires a valid SDSS user, represented by the `~sdss_brain.a
 either with ``.netrc`` or SDSS credentials, as indicated with the ``netrc`` and ``cred`` indicators in the ``repr``.
 Alternatively, you can check with the ``user.is_netrc_valid`` and ``user.is_sdss_valid`` properties.
 
-The "sdss" user
-^^^^^^^^^^^^^^^
+The "sdss(5)" user
+^^^^^^^^^^^^^^^^^^
 
-By default ``sdss_brain`` sets the default user in the global config to the generic "sdss" user.  The "sdss" user is the default
+The "sdss" user, or equivalently "sdss5" for SDSS-V, is a general, anonymous user that has access to SDSS data.  By default
+``sdss_brain`` sets the default user in the global config to the generic "sdss" user.  The "sdss" user is the default
 used for all remote data access and API requests using `~sdss_brain.api.client.SDSSClient`.
 ::
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -88,7 +88,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/python/sdss_brain/api/io.py
+++ b/python/sdss_brain/api/io.py
@@ -17,7 +17,7 @@ import httpx
 from sdss_brain.exceptions import BrainError
 
 
-def send_post_request(url: str, data: dict = None) -> dict:
+def send_post_request(url: str, data: dict = None, headers: dict = None) -> dict:
     """ A simple httpx post request
 
     A simple standalone httpx post request to a specified url, and
@@ -29,6 +29,8 @@ def send_post_request(url: str, data: dict = None) -> dict:
         The url to send the request to
     data : dict, optional
         Input data to send along with the request, by default None
+    headers : dict, optional
+        Optional custom request header info, by default None
 
     Returns
     -------
@@ -41,7 +43,7 @@ def send_post_request(url: str, data: dict = None) -> dict:
         when an error occurs sending the request
     """
     try:
-        resp = httpx.post(url, data=data)
+        resp = httpx.post(url, data=data, headers=headers)
     except httpx.RequestError as exc:
         raise BrainError(f'An error occurred requesting {exc.request.url!r}') from exc
     else:

--- a/python/sdss_brain/api/manager.py
+++ b/python/sdss_brain/api/manager.py
@@ -332,7 +332,7 @@ class ApiProfile(object):
                              'from response data. Check the returned json response '
                              'for prope key name')
 
-    def get_token(self, user: str) -> str:
+    def get_token(self, user: str) -> dict:
         """ Request and receive a valid API auth token
 
         Requests an auth token for the specified user.  This uses found netrc
@@ -341,6 +341,12 @@ class ApiProfile(object):
         the custom sdss_brain.yml configuration file as "xxx_api_token", where
         "XXX" is the API profile name.
 
+        Returns a dictionary containing an "access" key with your main auth token.
+        Optionally contains a "refresh" key with a token for refreshing your
+        access token.  The refresh token should be saved in an "XXX_API_REFRESH_TOKEN"
+        environment variable or in the custom sdss_brain.yml config file as
+        "xxx_api_refresh_token".
+
         Parameters
         ----------
         user : str
@@ -348,8 +354,8 @@ class ApiProfile(object):
 
         Returns
         -------
-        str
-            A valid API auth token
+        dict
+            A dict of valid API "access" and "refresh" auth token(s)
 
         Raises
         ------

--- a/python/sdss_brain/auth/netrc.py
+++ b/python/sdss_brain/auth/netrc.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division, absolute_import
 import netrc
 import pathlib
 import warnings
-from sdss_brain import cfg_params
+from sdss_brain import cfg_params, log
 from sdss_brain.exceptions import BrainError
 
 
@@ -135,8 +135,6 @@ class Netrc(object):
         ------
         BrainError
             when netrc file fails to pass checks
-        ValueError
-            when input host is not valid
         """
 
         if not self.check_netrc():
@@ -144,6 +142,8 @@ class Netrc(object):
 
         if not self.check_host(host):
             raise ValueError(f'{host} must be a valid host in the netrc')
+            #log.error(f'{host} must be a valid host in the netrc')
+            #return None, None
 
         netfile = netrc.netrc(self.path)
         user, acct, passwd = netfile.authenticators(host)  # pylint: disable=unused-variable

--- a/python/sdss_brain/auth/netrc.py
+++ b/python/sdss_brain/auth/netrc.py
@@ -141,9 +141,9 @@ class Netrc(object):
             raise BrainError('netrc did not pass checks.  Cannot read!')
 
         if not self.check_host(host):
-            raise ValueError(f'{host} must be a valid host in the netrc')
-            #log.error(f'{host} must be a valid host in the netrc')
-            #return None, None
+            # change from ValueErorr raise, to issue warning and return
+            log.error(f'{host} must be a valid host in the netrc')
+            return None, None
 
         netfile = netrc.netrc(self.path)
         user, acct, passwd = netfile.authenticators(host)  # pylint: disable=unused-variable

--- a/python/sdss_brain/auth/user.py
+++ b/python/sdss_brain/auth/user.py
@@ -141,6 +141,8 @@ class User(object):
         Raises
         ------
         ValueError
+            when no matching user can be found in the netrc file
+        ValueError
             when the netrc username does not match the input user
         ValueError
             when no valid password is input nor extracted from the netrc
@@ -154,10 +156,14 @@ class User(object):
                     pass
                 else:
                     self._validated_netrc_host = host
+                    # on successful user, break out of loop
+                    break
 
-            # if not user:
-            #     raise ValueError('No user found for any of the allowed netrc hosts.')
+            # if there is no user, fail
+            if not user:
+                raise ValueError('No user found for any of the allowed netrc hosts.')
 
+            # if users are mismatched, fail
             if user != self.user:
                 raise ValueError(f'netrc user {user} mismatched with input user {self.user}!')
 

--- a/python/sdss_brain/auth/user.py
+++ b/python/sdss_brain/auth/user.py
@@ -82,10 +82,10 @@ class User(object):
                                     for h in net_hosts)
             self._validated_netrc_host = vhost if self._valid_netrc else None
 
-            self._valid_netrc = (self.user in self.netrc.read_netrc('data.sdss.org') or
-                                 self.user in self.netrc.read_netrc('api.sdss.org') or
-                                 self.user in self.netrc.read_netrc('data.sdss5.org') or
-                                 self.user in self.netrc.read_netrc('wiki.sdss.org'))
+            # self._valid_netrc = (self.user in self.netrc.read_netrc('data.sdss.org') or
+            #                      self.user in self.netrc.read_netrc('api.sdss.org') or
+            #                      self.user in self.netrc.read_netrc('data.sdss5.org') or
+            #                      self.user in self.netrc.read_netrc('wiki.sdss.org'))
 
         # setup htpass
         try:
@@ -154,6 +154,9 @@ class User(object):
                     pass
                 else:
                     self._validated_netrc_host = host
+
+            # if not user:
+            #     raise ValueError('No user found for any of the allowed netrc hosts.')
 
             if user != self.user:
                 raise ValueError(f'netrc user {user} mismatched with input user {self.user}!')

--- a/python/sdss_brain/etc/api_profiles.yml
+++ b/python/sdss_brain/etc/api_profiles.yml
@@ -75,7 +75,10 @@ domains:
 #     affix: whether the alternate base is a prefix or suffix
 #   api: whether the API is under an "api" stem
 #   routemap: an API route that returns the available routes on the given API
-#   auth: the type of authentication the API needs for non-public APIs
+#   auth:
+#     type: the type of authentication the API needs for non-public APIs
+#     route: the route of the login
+#     refresh: the route to refresh the token
 
 apis:
   marvin:
@@ -119,3 +122,4 @@ apis:
     auth:
       type: token
       route: auth/login
+      refresh: auth/refresh

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -26,7 +26,7 @@ api_prof = {'marvin': {'description': 'API for accessing MaNGA data via Marvin',
                        'stems': {'test': 'test', 'public': 'public', 'affix': 'prefix'},
                        'api': True,
                        'routemap': 'general/getroutemap/',
-                       'auth': {'type': 'token', 'route': 'general/login/'}}
+                       'auth': {'type': 'token', 'route': 'general/login/', 'refresh': '/general/refresh/'}}
             }
 
 
@@ -52,5 +52,6 @@ def mock_profile(mock_api, mock_user):
     from sdss_brain.api.manager import ApiProfile
     profile = ApiProfile('marvin')
     profile.check_for_token = lambda: 'xyz123'
+    profile.check_for_refresh_token = lambda: 'abc123'
     yield profile
     profile = None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -36,10 +36,14 @@ def mock_api(monkeypatch):
     monkeypatch.setattr(sdss_brain.api.manager, 'apis', api_prof)
 
 @pytest.fixture
-def mock_netrc():
+def mock_netrc(mocker):
     """ fixture to create a new mocked netrc object """
+    mocker.patch.object(Netrc, 'check_netrc', autospec=True)
+    mocker.patch.object(Netrc, 'check_host', autospec=True)
+
     n = Netrc()
     n.check_netrc = lambda: True
+    n.check_host = lambda: True
     n.read_netrc = lambda x : ("sdss", "test")
     yield n
     n = None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -16,7 +16,7 @@ import pytest
 
 import sdss_brain.api.manager
 from sdss_brain.auth.user import User
-
+from sdss_brain.auth.netrc import Netrc
 
 api_prof = {'marvin': {'description': 'API for accessing MaNGA data via Marvin',
                        'docs': 'https://sdss-marvin.readthedocs.io/en/stable/reference/web.html',
@@ -35,12 +35,21 @@ def mock_api(monkeypatch):
     """ fixture to mock the apis dictionary """
     monkeypatch.setattr(sdss_brain.api.manager, 'apis', api_prof)
 
+@pytest.fixture
+def mock_netrc():
+    """ fixture to create a new mocked netrc object """
+    n = Netrc()
+    n.check_netrc = lambda: True
+    n.read_netrc = lambda x : ("sdss", "test")
+    yield n
+    n = None
+
 
 @pytest.fixture()
-def mock_user():
+def mock_user(mock_netrc):
     """ fixture to create a new mocked sdss user """
     user = User('sdss')
-    user.netrc = True
+    user.netrc = mock_netrc
     user._valid_netrc = True
     yield user
     user = None

--- a/tests/api/test_manager.py
+++ b/tests/api/test_manager.py
@@ -128,13 +128,13 @@ class TestProfile(object):
         assert mock_profile.check_for_token() == 'xyz123'
         assert mock_profile.check_for_refresh_token() == 'abc123'
 
-    def test_get_token(self, respx_mock, mock_profile, monkeypatch):
+    def test_get_token(self, mock_user, respx_mock, mock_profile, monkeypatch):
         monkeypatch.setattr(mock_profile, 'check_for_token', lambda: None)
 
         url = 'https://sas.sdss.org/marvin/api/general/login/'
         respx_mock.post(url).mock(return_value=Response(200, json={'access_token': 'xyz123', 'refresh_token': 'abc123'}))
 
-        tokens = mock_profile.get_token('sdss')
+        tokens = mock_profile.get_token(mock_user)
         assert tokens['access'] == 'xyz123'
         assert tokens['refresh'] == 'abc123'
 


### PR DESCRIPTION
This PR closes #21 and adds support to API profiles for refreshing authentication tokens.  There is a new ``refresh_token`` property, which checks for a saved refresh token using ``check_for_refresh_token``.  ``get_token`` method now returns a dict of `{'access': token, 'refresh': token}`, containing the relevant tokens.  A new access token can be generated from the API using a new `refresh_auth_token` method. 