### PR TITLE
Adds datamodels into tools

### DIFF
--- a/python/sdss_brain/api/client.py
+++ b/python/sdss_brain/api/client.py
@@ -100,6 +100,9 @@ class BaseClient(object):
         # set the URL
         self.set_url(route)
 
+        # automatically follow redirects
+        kwargs['follow_redirects'] = True
+
         # set the httpx.Client or httpx.AsyncClient
         self.client = self._kls(headers=headers, **kwargs)  # pylint: disable=not-callable
 

--- a/python/sdss_brain/core.py
+++ b/python/sdss_brain/core.py
@@ -19,6 +19,7 @@ from sdss_brain.exceptions import BrainError
 from sdss_brain.helpers import db_type
 from sdss_brain.api.handler import api_type, ApiHandler
 from sdss_brain.mixins.mma import MMAccess, MMAMixIn
+from sdss_brain.mixins.datamodel import DataModelMixIn
 from astropy.io import fits
 
 
@@ -274,7 +275,7 @@ class HindBrain(Base):
         cls._api = value
 
 
-class Brain(HindBrain, MMAccess):
+class Brain(DataModelMixIn, HindBrain, MMAccess):
     """ The hind Brain with support for ``sdss_access``
 
     See `~HindBrain`, `~sdss_brain.mixins.mma.MMAccess`, and `~sdss_brain.mixins.access.AccessMixIn`
@@ -283,7 +284,7 @@ class Brain(HindBrain, MMAccess):
     """
 
 
-class BrainNoAccess(HindBrain, MMAMixIn):
+class BrainNoAccess(DataModelMixIn, HindBrain, MMAMixIn):
     """ A version of `~Brain` without support for ``sdss_access``
 
     See `~HindBrain` and `~sdss_brain.mixins.mma.MMAMixIn` for detailed

--- a/python/sdss_brain/datamodel/products.py
+++ b/python/sdss_brain/datamodel/products.py
@@ -354,11 +354,12 @@ class Model:
             when the data release specified is not an allowed release
         """
         release = release or self.release or config.release
-        if release not in self.releases:
-            raise ValueError(f'Release {release} is not a valid release for model {self.name}.')
-
-        self.release_model = copy.deepcopy(self._model.releases[release])
         self.release = release
+        if release not in self.releases:
+            log.warning(f'Release {release} is not a valid release for model "{self.name}".')
+            self.release_model = None
+        else:
+            self.release_model = copy.deepcopy(self._model.releases[release])
 
     @release_check
     def get_hdu(self, ext: Union[int, str]):

--- a/python/sdss_brain/datamodel/products.py
+++ b/python/sdss_brain/datamodel/products.py
@@ -395,9 +395,27 @@ class Model:
         return self.release_model.hdus[extname]
 
     @release_check
-    def list_hdus(self):
-        """ List the available HDUs """
-        return self.release_model.hdus
+    def list_hdus(self, names: bool = None) -> Union[list, dict]:
+        """ List the available HDUs
+
+        Returns a dictionary of HDU model objects from the datamodel.
+        To return a list of HDU string names, set the ``names``
+        keyword to True.
+
+        Parameters
+        ----------
+        names : bool, optional
+            If set, returns the HDU extension names, by default None
+
+        Returns
+        -------
+        Union[list, dict]
+            A list or dict of available HDUs
+        """
+        if names:
+            return [i.name for i in self.release_model.hdus.values()]
+        else:
+            return self.release_model.hdus
 
     @classmethod
     def from_datamodel(cls, model: Union[str, ProdModel], release: str = None) -> ModelType:
@@ -518,3 +536,33 @@ class Models(list):
 
 
 models = Models(list_datamodels(release=config.release))
+
+
+def create_object_model(name: str, release: str = None) -> ModelType:
+    """ Create a datamodel object
+
+    Create a datamodel object for a given file species
+    product name and data release.
+
+    Parameters
+    ----------
+    name : str
+        a file species product name
+    release : str, optional
+        the SDSS data release, by default None
+
+    Returns
+    -------
+    ModelType
+        an instance of a product datamodel
+    """
+    if not name:
+        return None
+
+    mod = Model.from_datamodel(name, release=release)
+    if mod and not mod.name:
+        log.warning(f'No model found for product: {name}.')
+        return
+
+    return mod
+

--- a/python/sdss_brain/etc/sdss_brain.yml
+++ b/python/sdss_brain/etc/sdss_brain.yml
@@ -20,6 +20,7 @@ mapped_versions:
     MPL5: {drpver: v2_0_1, dapver: 2.0.2}
     MPL4: {drpver: v1_5_1, dapver: 1.1.1}
   eboss:
+    DR18: v6_0_4
     DR17: v5_13_2
     DR16: v5_13_0
     DR15: v5_10_0
@@ -29,6 +30,7 @@ mapped_versions:
     DR11: v5_6_5
     DR10: v5_5_12
     DR9: v5_4_45
+    IPL1: v6_0_9
   apogee:
     DR17: dr17
     DR16: r12
@@ -38,3 +40,4 @@ mapped_versions:
     DR12: r5
     DR11: r4
     DR10: r3
+    IPL1: 1.0

--- a/python/sdss_brain/mixins/datamodel.py
+++ b/python/sdss_brain/mixins/datamodel.py
@@ -39,9 +39,13 @@ class DataModelMixIn:
             log.warning('No data or datamodel attributes specified.  Cannot check.')
             return
 
-        model_hdus = set(self.datamodel.list_hdus(names=True))
+        model_hdus = self.datamodel.list_hdus(names=True)
+        if not model_hdus:
+            log.warning(f'No HDUS found for model {self.datamodel.name} in release {self.release}.')
+            return
+
         data_hdus = {i.name for i in self.data}
-        if missing := data_hdus - model_hdus:
+        if missing := data_hdus - set(model_hdus):
             log.warning("HDU extension mismatch between loaded data and expected datamodel. "
                         f"Loaded data has extra extensions: {missing}")
             return False

--- a/python/sdss_brain/mixins/datamodel.py
+++ b/python/sdss_brain/mixins/datamodel.py
@@ -1,0 +1,52 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+from __future__ import print_function, division, absolute_import
+
+from sdss_brain.config import config, log
+from sdss_brain.datamodel.products import create_object_model
+
+
+__all__ = ['DataModelMixIn']
+
+
+class DataModelMixIn:
+    """ Class to handle datamodel """
+    datamodel: str = None
+
+    def __init__(self, *args, model: str = None, **kwargs):
+        release = kwargs.get('release') or config.release
+        name = model or getattr(self.__class__, 'datamodel', None)
+        self.datamodel = create_object_model(name, release=release)
+
+        super(DataModelMixIn, self).__init__(*args, **kwargs)
+
+    def check_data(self) -> bool:
+        """ Check the data against the set datamodel
+
+        Checks the currently loaded data against the expected
+        datamodel for any discrepant HDU extensions. Returns
+        True if no discrepanices or False if the loaded
+        data has extensions not in the datamodel.
+
+        Returns
+        -------
+        bool
+            _description_
+        """
+        if not self.data or not self.datamodel:
+            log.warning('No data or datamodel attributes specified.  Cannot check.')
+            return
+
+        model_hdus = set(self.datamodel.list_hdus(names=True))
+        data_hdus = {i.name for i in self.data}
+        if missing := data_hdus - model_hdus:
+            log.warning("HDU extension mismatch between loaded data and expected datamodel. "
+                        f"Loaded data has extra extensions: {missing}")
+            return False
+        return True
+
+
+
+

--- a/python/sdss_brain/tools/cubes.py
+++ b/python/sdss_brain/tools/cubes.py
@@ -30,6 +30,7 @@ class Cube(Spectrum):
 class MangaCube(Spectrum):
     """ Class representing a MaNGA IFU datacube for a single galaxy """
     specutils_format: str = 'MaNGA cube'
+    datamodel: str = 'mangaCube'
     _api = ('marvin', 'cubes/{plateifu}/')
 
     def _load_object_from_db(self):

--- a/python/sdss_brain/tools/spectra.py
+++ b/python/sdss_brain/tools/spectra.py
@@ -22,7 +22,7 @@ except ImportError:
 from astropy.io.registry import IORegistryError
 from astropy.io.fits import HDUList
 from specutils import Spectrum1D
-from typing import Type, Union, BinaryIO, TypeVar
+from typing import Type, Union, BinaryIO, List
 
 from sdss_brain import log
 from sdss_brain.core import Brain
@@ -227,7 +227,7 @@ class AspcapStar(Spectrum):
 def create_tool(species: str, base: Union[tuple, list, Spectrum] = None, specutils_format: str = None,
                 release: str = None,  api: str = None, base_api_route: str = None,
                 path_name: str = None, mapped_version: str = None, pattern: str = None, delimiter: str = None,
-                defaults: dict = None, order: list[str] = None, keys: list = None, keymap: dict = None,
+                defaults: dict = None, order: List[str] = None, keys: list = None, keymap: dict = None,
                 exclude: list = None, include: list = None) -> Type[Spectrum]:
     """ Dynamically create a new tool
 
@@ -266,7 +266,7 @@ def create_tool(species: str, base: Union[tuple, list, Spectrum] = None, specuti
         the regex pattern to match with, by default None
     delimiter : str, optional
         the delimiter to use when joining keys for the objectid pattern creation, by default None
-    order : list[str], optional
+    order : List[str], optional
         a list of access keywords to order the objectid pattern by, by default None
     keys : list, optional
         optional list of names to construct a named pattern.  Default is to use any sdss_access keys.

--- a/python/sdss_brain/tools/spectra.py
+++ b/python/sdss_brain/tools/spectra.py
@@ -22,7 +22,7 @@ except ImportError:
 from astropy.io.registry import IORegistryError
 from astropy.io.fits import HDUList
 from specutils import Spectrum1D
-from typing import Type, Union, BinaryIO
+from typing import Type, Union, BinaryIO, TypeVar
 
 from sdss_brain import log
 from sdss_brain.core import Brain
@@ -222,3 +222,120 @@ class AspcapStar(Spectrum):
         # set the path params using the instance attributes extracted from _parse_input
         self.path_params = {'telescope': self.telescope, 'apred': apred,
                             'field': self.field, 'obj': self.obj, 'aspcap': self.aspcap}
+
+
+def create_tool(species: str, base: Union[tuple, list, Spectrum] = None, specutils_format: str = None,
+                release: str = None,  api: str = None, base_api_route: str = None,
+                path_name: str = None, mapped_version: str = None, pattern: str = None, delimiter: str = None,
+                defaults: dict = None, order: list[str] = None, keys: list = None, keymap: dict = None,
+                exclude: list = None, include: list = None) -> Type[Spectrum]:
+    """ Dynamically create a new tool
+
+    Creates a new tool class dynamically from a datamodel file species product name. The new tool is
+    subclassed from `~.sdss_brain.tools.spectra.Spectrum`, but the base class can be customized with
+    the ``base`` option.  The new class is wrapped in the ``sdss_loader`` decorator, which provides
+    convenience for specifying a unique object identifier for the tool, and any sdss_access information.
+
+    Keyword arguments ``specutils_format``, ``api``, and ``base_api_route``, along with the ``species``
+    argument are used to define tool class attributes.
+
+    The remainder of the keyword arguments are those passed to the ``sdss_loader`` decorator for defining
+    a unique object id pattern, as well as the pertinent sdss_access parameters.
+
+    Parameters
+    ----------
+    species : str
+        a file species product name
+    base : Union[tuple, list, Spectrum], optional
+        a new base class or tuple of classes to subclass from, by default Spectrum
+    specutils_format : str, optional
+        the format identifier used by specutils.Spectrum1D, by default None
+    release : str, optional
+        the SDSS data release, by default None
+    api : str, optional
+        the name of the API to use, by default None
+    base_api_route : str, optional
+        the base API route for this tool, by default None
+    path_name : str, optional
+        the sdss_access template path name, by default None
+    mapped_version : str, optional
+        a mapping key to map a specific version onto a release, e.g. "manga:drpver", by default None
+    defaults : dict, optional
+        default values for the sdss_access template keyword arguments, by default None
+    pattern : str, optional
+        the regex pattern to match with, by default None
+    delimiter : str, optional
+        the delimiter to use when joining keys for the objectid pattern creation, by default None
+    order : list[str], optional
+        a list of access keywords to order the objectid pattern by, by default None
+    keys : list, optional
+        optional list of names to construct a named pattern.  Default is to use any sdss_access keys.
+    keymap : dict, optional
+        optional dict mapping names to specific patterns to use, by default None
+    exclude : list, optional
+        a list of access keywords to exclude in the objectid pattern creation, by default None
+    include : list, optional
+        a list of access keywords to include in the objectid pattern creation, by default None
+
+    Returns
+    -------
+    Spectrum
+        a new tool class
+
+    Raises
+    ------
+    ValueError
+        when no mapped_version is specified
+    """
+    # create class name
+    name = species[0].title() + species[1:]
+
+    # set class attributes
+    kwds = {'datamodel': species, 'specutils_format': specutils_format}
+
+    # check for any api info
+    if api:
+        api_tup = (api, base_api_route)
+        kwds['_api'] = api_tup
+
+    # resolve the bases
+    if not base:
+        base = (Spectrum,)
+    elif isinstance(base, list):
+        base = tuple(base)
+    elif not isinstance(base, tuple):
+        base = (base,)
+    from types import resolve_bases
+    resolved_bases = resolve_bases(base)
+
+    # create the new class
+    kls = type(name, resolved_bases, kwds)
+
+    # TODO - improve the inputs and code around mapped_versions
+    # TODO - improve the inputs and code around path keywords and object id creation
+    # NOTE - can we reduce the number of inputs and auto-input to sdss_loader?
+
+    # check inputs
+    if not mapped_version:
+        raise ValueError('A mapped_version must be specified.')
+
+    # look up path name if none is specified
+    if not path_name:
+        # create datamodel
+        from sdss_brain.datamodel.products import create_object_model
+        model = create_object_model(species, release=release)
+
+        info = model.get_access_info()
+        if not info or info['in_sdss_access'] is False:
+            log.warning(f'No access info found for datamodel {name} in {release}.')
+            return
+
+        path_name = info['path_name']
+
+
+    # apply the sdss_loader decorator
+    kls = sdss_loader(name=path_name, defaults=defaults or {}, delimiter=delimiter,
+                    mapped_version=mapped_version, order=order, pattern=pattern,
+                    keys=keys, keymap=keymap, exclude=exclude, include=include)(kls)
+
+    return kls

--- a/tests/models/test_products.py
+++ b/tests/models/test_products.py
@@ -5,7 +5,6 @@
 import pytest
 import json
 import pathlib
-import importlib
 import respx
 from httpx import Response
 from pydantic import BaseModel

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -16,6 +16,7 @@ import pytest
 import pathlib
 from sdss_brain.config import config
 from tests.conftest import object_data, check_path
+from tests.models.test_products import testmodel
 
 
 @pytest.fixture()
@@ -90,6 +91,12 @@ class WorkTests(object):
     """
     version = None
     mock = None
+    model = None
+
+    @pytest.fixture(autouse=True)
+    def mock_model(self, mocker, testmodel):
+        testmodel.general.name = self.model
+        mocker.patch('sdss_brain.datamodel.products.get_datamodel', return_value=testmodel)
 
     def assert_file(self, inst, path):
         assert inst.filename is not None

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -81,8 +81,15 @@ def get_mocked(kls):
 
     return Mocked
 
+class BaseTests(object):
+    model = None
 
-class WorkTests(object):
+    @pytest.fixture(autouse=True)
+    def mock_model(self, mocker, testmodel):
+        testmodel.general.name = self.model
+        mocker.patch('sdss_brain.datamodel.products.get_datamodel', return_value=testmodel)
+
+class WorkTests(BaseTests):
     """ Class that tests that the class attributes and path_params
 
     This class tests that a Brain sub-class sets instance attributes and path_params
@@ -92,11 +99,6 @@ class WorkTests(object):
     version = None
     mock = None
     model = None
-
-    @pytest.fixture(autouse=True)
-    def mock_model(self, mocker, testmodel):
-        testmodel.general.name = self.model
-        mocker.patch('sdss_brain.datamodel.products.get_datamodel', return_value=testmodel)
 
     def assert_file(self, inst, path):
         assert inst.filename is not None

--- a/tests/tools/test_eboss.py
+++ b/tests/tools/test_eboss.py
@@ -53,3 +53,34 @@ class TestEbossWorkFails(object):
     def test_release_version_set(self):
         with pytest.raises(BrainError, match='version is only used for "work" data.'):
             Eboss('3606-55182-0537', release='DR14', version={'run2d': 'v5_10_0'})
+
+
+@pytest.mark.use_test_data('eboss', fake_missing=True)
+class TestEbossDataModel(WorkTests):
+    mock = get_mocked(Eboss)
+    version = 'run2d'
+
+    def assert_model(self, inst):
+        assert hasattr(inst, 'datamodel')
+        assert inst.datamodel is not None
+        assert inst.release == inst.datamodel.release
+        assert inst.datamodel.name == 'specLite'
+
+    def get_tool(self, release):
+        e = Eboss('3606-55182-0537', release=release)
+        self.assert_model(e)
+        assert e.datamodel.release == release
+        return e
+
+    def test_datamodel(self):
+        e = self.get_tool('DR14')
+        assert e.datamodel.release_model is not None
+
+    def test_dm_no_release(self):
+        e =  self.get_tool('WORK')
+        assert e.datamodel.release_model is None
+
+
+
+
+

--- a/tests/tools/test_eboss.py
+++ b/tests/tools/test_eboss.py
@@ -19,7 +19,6 @@ from sdss_brain.exceptions import BrainError
 from .conftest import WorkTests, get_mocked
 from tests.conftest import object_data
 
-
 releases = object_data.get('eboss').keys()
 
 
@@ -59,6 +58,7 @@ class TestEbossWorkFails(object):
 class TestEbossDataModel(WorkTests):
     mock = get_mocked(Eboss)
     version = 'run2d'
+    model = 'specLite'
 
     def assert_model(self, inst):
         assert hasattr(inst, 'datamodel')
@@ -73,7 +73,7 @@ class TestEbossDataModel(WorkTests):
         return e
 
     def test_datamodel(self):
-        e = self.get_tool('DR14')
+        e = self.get_tool('DR17')
         assert e.datamodel.release_model is not None
 
     def test_dm_no_release(self):

--- a/tests/tools/test_eboss.py
+++ b/tests/tools/test_eboss.py
@@ -16,7 +16,7 @@ import pytest
 from sdss_brain.tools.spectra import Eboss
 from sdss_brain.config import config
 from sdss_brain.exceptions import BrainError
-from .conftest import WorkTests, get_mocked
+from .conftest import WorkTests, get_mocked, BaseTests
 from tests.conftest import object_data
 
 releases = object_data.get('eboss').keys()
@@ -42,7 +42,7 @@ class TestEbossWorkVersions(WorkTests):
         assert Eboss._version == {'run2d': 'v5_10_0'}
 
 
-class TestEbossWorkFails(object):
+class TestEbossWorkFails(BaseTests):
 
     def test_no_work_version_set(self, monkeypatch):
         monkeypatch.setattr(config, 'work_versions', {})


### PR DESCRIPTION
Closes #28 .  This PR provides support for connecting datamodels to existing or new tools.  There is a new `DataModelMixIn` class that is mixed into the `Brain` class that allows for tools to hook into their datamodels.  For a tool to connect to a datamodel, a new `datamodel` class attribute should be set to the tool's "file species" name, as given in the SDSS datamodel product.  Current limitations are one datamodel per tool.  It also adds a new function, `create_tool`, for dynamically creating a new tool class, which by default subclasses from `Spectrum`.  